### PR TITLE
Docker builder

### DIFF
--- a/Dockerfile-jessie
+++ b/Dockerfile-jessie
@@ -1,0 +1,19 @@
+FROM multiarch/debian-debootstrap:armhf-jessie
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+
+# sensible-build.sh deps
+RUN apt-get install -y --no-install-recommends \
+       git ca-certificates wget patch \
+       build-essential debhelper dpkg-dev
+
+# build dpes
+RUN apt-get install -y --no-install-recommends \
+       debhelper tcl8.6-dev autoconf python3-dev python3-venv libz-dev dh-systemd openssl
+
+# runtime deps
+RUN apt-get install -y --no-install-recommends \
+       net-tools iproute2 tclx8.4 tcl8.6 tcllib tcl-tls itcl3
+
+RUN apt-get install -y --no-install-recommends devscripts equivs

--- a/Dockerfile-stretch
+++ b/Dockerfile-stretch
@@ -1,0 +1,18 @@
+FROM multiarch/debian-debootstrap:armhf-stretch
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update
+
+# sensible-build.sh deps and deb packing debs
+RUN apt-get install -y --no-install-recommends \
+       git ca-certificates wget patch \
+       build-essential debhelper dpkg-dev \
+       devscripts equivs
+
+# build dpes
+RUN apt-get install -y --no-install-recommends \
+       debhelper tcl8.6-dev autoconf python3-dev python3-venv libz-dev dh-systemd openssl
+
+# runtime deps
+RUN apt-get install -y --no-install-recommends \
+       net-tools iproute2 tclx8.4 tcl8.6 tcllib tcl-tls itcl3

--- a/Dockerfile-wheezy
+++ b/Dockerfile-wheezy
@@ -1,4 +1,4 @@
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-wheezy
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
@@ -11,8 +11,8 @@ RUN apt-get install -y --no-install-recommends \
 
 # build dpes
 RUN apt-get install -y --no-install-recommends \
-       debhelper tcl8.6-dev autoconf python3-dev python3-venv libz-dev dh-systemd openssl
+       debhelper tcl8.5-dev autoconf python3-dev python-virtualenv libz-dev openssl
 
 # runtime deps
 RUN apt-get install -y --no-install-recommends \
-       net-tools iproute2 tclx8.4 tcl8.6 tcllib tcl-tls itcl3
+       net-tools iproute tclx8.4 tcl8.5 tcllib tcl-tls itcl3

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -9,21 +9,28 @@ set -o pipefail         # Use last non-zero exit code in a pipeline
 DISTRIBUTION=${1}
 
 DOCKER_IMAGE_NANE="piaware-builder:${DISTRIBUTION}"
-DOCKER_CONTINAER_NANE='piaware-builder'
+DOCKER_CONTINAER_NANE="piaware-builder-${DISTRIBUTION}"
 
 # build builder image
 docker build --tag "${DOCKER_IMAGE_NANE}" --file "Dockerfile-${DISTRIBUTION}" .
 
+# Setup the build env
 mkdir -p "package-${DISTRIBUTION}"
 docker run --rm -it --name "${DOCKER_CONTINAER_NANE}" \
+    -u="${UID}:$(id -g ${USER})" -v '/etc/group:/etc/group:ro' -v '/etc/passwd:/etc/passwd:ro' \
     -v "${PWD}:/build:ro" \
     -v "${PWD}/package-${DISTRIBUTION}:/build/package-${DISTRIBUTION}:rw" \
     --workdir="/build" "${DOCKER_IMAGE_NANE}" \
     ./sensible-build.sh "${DISTRIBUTION}"
 
+# build the deb packages
 mkdir -p "debs-${DISTRIBUTION}"
 docker run --rm -it --name "${DOCKER_CONTINAER_NANE}" \
+    -u="${UID}:$(id -g ${USER})" -v '/etc/group:/etc/group:ro' -v '/etc/passwd:/etc/passwd:ro' \
     -v "${PWD}/debs-${DISTRIBUTION}:/build:rw" \
     -v "${PWD}/package-${DISTRIBUTION}:/build/package-${DISTRIBUTION}:rw" \
     --workdir="/build/package-${DISTRIBUTION}" \
     "${DOCKER_IMAGE_NANE}" dpkg-buildpackage -b
+
+rm -rf "package-${DISTRIBUTION}"
+rm -rf "debs-${DISTRIBUTION}/package-${DISTRIBUTION}"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -o errexit          # Exit on most errors (see the manual)
+set -o errtrace         # Make sure any error trap is inherited
+set -o nounset          # Disallow expansion of unset variables
+set -o pipefail         # Use last non-zero exit code in a pipeline
+#set -o xtrace          # Trace the execution of the script (debug)
+
+DISTRIBUTION=${1}
+
+DOCKER_IMAGE_NANE="piaware-builder:${DISTRIBUTION}"
+DOCKER_CONTINAER_NANE='piaware-builder'
+
+# build builder image
+docker build --tag "${DOCKER_IMAGE_NANE}" --file "Dockerfile-${DISTRIBUTION}" .
+
+mkdir -p "package-${DISTRIBUTION}"
+docker run --rm -it --name "${DOCKER_CONTINAER_NANE}" \
+    -v "${PWD}:/build:ro" \
+    -v "${PWD}/package-${DISTRIBUTION}:/build/package-${DISTRIBUTION}:rw" \
+    --workdir="/build" "${DOCKER_IMAGE_NANE}" \
+    ./sensible-build.sh "${DISTRIBUTION}"
+
+mkdir -p "debs-${DISTRIBUTION}"
+docker run --rm -it --name "${DOCKER_CONTINAER_NANE}" \
+    -v "${PWD}/debs-${DISTRIBUTION}:/build:rw" \
+    -v "${PWD}/package-${DISTRIBUTION}:/build/package-${DISTRIBUTION}:rw" \
+    --workdir="/build/package-${DISTRIBUTION}" \
+    "${DOCKER_IMAGE_NANE}" dpkg-buildpackage -b


### PR DESCRIPTION
Add a script to build the debs via Docker.

The aim of this is to enable a simple and clean way to build the debs without affecting the current system. This also has the byproduct to enabling CI (Travis) and building the ARM build on any platform via QEMU.

This is more of a "request of comments" than a polished pull request so please let me know if this is interesting for any further work. There is a working Travis build at https://travis-ci.org/TheBiggerGuy/piaware_builder 