### PR TITLE
Fix noble wheel packaging globs

### DIFF
--- a/cx_Freeze-8.5.0.patch
+++ b/cx_Freeze-8.5.0.patch
@@ -1,0 +1,21 @@
+diff -ur cx_Freeze-8.5.0/pyproject.toml cx_Freeze-8.5.0.new/pyproject.toml
+--- cx_Freeze-8.5.0/pyproject.toml
++++ cx_Freeze-8.5.0.new/pyproject.toml
+@@ -49,8 +49,7 @@
+ ]
+ dynamic = ["version"]
+ keywords = ["cx-freeze cxfreeze cx_Freeze freeze python"]
+-license = "PSF-2.0"
+-license-files = ["LICENSE.md"]
++license = {text = "PSF-2.0"}
+ readme = "README.md"
+ requires-python = ">=3.10"
+ 
+@@ -105,6 +104,7 @@
+ 
+ [tool.setuptools]
+ include-package-data = true
++license-files = ["LICENSE.md"]
+ zip-safe = false
+ 
+ [tool.setuptools.dynamic]

--- a/freeze-core-0.4.2.patch
+++ b/freeze-core-0.4.2.patch
@@ -1,0 +1,20 @@
+diff -ur freeze-core-0.4.2/pyproject.toml freeze-core-0.4.2.new/pyproject.toml
+--- freeze-core-0.4.2/pyproject.toml
++++ freeze-core-0.4.2.new/pyproject.toml
+@@ -39,8 +39,7 @@
+ ]
+ dynamic = ["version"]
+ keywords = ["freeze-core freeze cx-freeze cxfreeze cx_Freeze python"]
+-license = "MIT"
+-license-files = ["LICENSE"]
++license = {text = "MIT"}
+ readme = "README.md"
+ requires-python = ">=3.10"
+ 
+@@ -68,6 +67,7 @@
+ 
+ [tool.setuptools]
+ include-package-data = true
++license-files = ["LICENSE"]
+ package-dir = {"" = "src"}
+ zip-safe = false

--- a/trixie/rules
+++ b/trixie/rules
@@ -84,10 +84,10 @@ build_mlat-client:
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel -C="--build-option=--plat-name" -C="--build-option=$(PYTHON_HOST_PLATFORM)" --outdir $(CURDIR)/wheels freeze-core-0.4.2
 	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/freeze_core-0.4.2*.whl
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel -C="--build-option=--plat-name" -C="--build-option=$(PYTHON_HOST_PLATFORM)" --outdir $(CURDIR)/wheels cx_Freeze-8.5.0
-	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/cx_freeze-8.5.0*.whl
+	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/cx_Freeze-8.5.0-*.whl
 	# build mlat-client proper
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel -C="--build-option=--plat-name" -C="--build-option=$(PYTHON_HOST_PLATFORM)" --outdir $(CURDIR)/wheels mlat-client
-	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/mlatclient-*.whl
+	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/MlatClient-*.whl
 
 install_mlat-client:
 	# newer cxfreeze deletes --target-dir (see cxfreeze issue #1300), so we have to freeze to a temporary directory and


### PR DESCRIPTION
 Fixed the Ubuntu 24.04 (noble) packaging path for piaware.

The build was failing in the vendored Python packaging steps used for mlat-client freezing. Two upstream tarballs, freeze-core-0.4.2 and cx_Freeze-8.5.0, ship pyproject.toml metadata that newer upstream tooling accepts but Ubuntu 24.04’s setuptools rejects. 

This change patches both archives during sensible-build.sh preparation so their license metadata is compatible with the distro toolchain. It also fixes the trixie packaging recipe to install the generated wheels using the correct wheel filename patterns for cx_Freeze and MlatClient.

Successfully builds in github actions.