### PR TITLE
Ubuntu 22.04 (jammy) and 24.04 (noble) packaging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,32 @@
+name: Build piaware packages
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    name: Build piaware packages
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.image }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      - name: Prepare environment vars
+        run: |
+          echo "BUILDDIR=${{ runner.temp }}/build" >>$GITHUB_ENV
+      - name: Prepare build tree
+        run: |
+          . /etc/os-release
+          ./prepare-build.sh $VERSION_CODENAME $BUILDDIR
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends devscripts equivs
+          cd ${{ runner.temp }} && mk-build-deps --tool "apt-get -y --no-install-recommends" --root-cmd sudo --install --remove $BUILDDIR/debian/control
+      - name: Build package
+        run: |
+          cd $BUILDDIR && dpkg-buildpackage -b --no-sign

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
           $GITHUB_WORKSPACE/sensible-build.sh $VERSION_CODENAME $BUILDDIR
       - name: Install build prerequisites
         run: |
-          cd ${{ runner.temp }} && mk-build-deps --tool "apt-get -y --no-install-recommends" --root-cmd sudo --install --remove $BUILDDIR/debian/control
+          cd ${{ runner.temp }} && mk-build-deps --tool "apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends" --root-cmd sudo --install --remove $BUILDDIR/debian/control
       - name: Build package
         run: |
           cd $BUILDDIR && dpkg-buildpackage -b --no-sign

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,14 +18,16 @@ jobs:
       - name: Prepare environment vars
         run: |
           echo "BUILDDIR=${{ runner.temp }}/build" >>$GITHUB_ENV
+      - name: Install early build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends devscripts equivs
       - name: Prepare build tree
         run: |
           . /etc/os-release
           $GITHUB_WORKSPACE/sensible-build.sh $VERSION_CODENAME $BUILDDIR
       - name: Install build prerequisites
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends devscripts equivs
           cd ${{ runner.temp }} && mk-build-deps --tool "apt-get -y --no-install-recommends" --root-cmd sudo --install --remove $BUILDDIR/debian/control
       - name: Build package
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Prepare build tree
         run: |
           . /etc/os-release
-          ./prepare-build.sh $VERSION_CODENAME $BUILDDIR
+          $GITHUB_WORKSPACE/prepare-build.sh $VERSION_CODENAME $BUILDDIR
       - name: Install build prerequisites
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.image }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,8 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.image }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,3 +32,8 @@ jobs:
       - name: Build package
         run: |
           cd $BUILDDIR && dpkg-buildpackage -b --no-sign
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: piaware-${{ matrix.image }}
+          path: ${{ runner.temp }}/*.deb

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Prepare build tree
         run: |
           . /etc/os-release
-          $GITHUB_WORKSPACE/prepare-build.sh $VERSION_CODENAME $BUILDDIR
+          $GITHUB_WORKSPACE/sensible-build.sh $VERSION_CODENAME $BUILDDIR
       - name: Install build prerequisites
         run: |
           sudo apt-get update

--- a/bookworm/control
+++ b/bookworm/control
@@ -2,7 +2,7 @@ Source: piaware
 Section: embedded
 Priority: extra
 Maintainer: FlightAware Developers <adsb-devs@flightaware.com>
-Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools, python3-wheel (>=0.38.4), python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
+Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools (>=62.6), python3-wheel (>=0.38.4), python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
 Standards-Version: 3.9.3
 Homepage: https://github.com/flightaware
 

--- a/bookworm/control
+++ b/bookworm/control
@@ -2,7 +2,7 @@ Source: piaware
 Section: embedded
 Priority: extra
 Maintainer: FlightAware Developers <adsb-devs@flightaware.com>
-Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools, python3-wheel (>=0.38.4), python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
+Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools, python3-wheel, python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
 Standards-Version: 3.9.3
 Homepage: https://github.com/flightaware
 

--- a/bookworm/control
+++ b/bookworm/control
@@ -2,7 +2,7 @@ Source: piaware
 Section: embedded
 Priority: extra
 Maintainer: FlightAware Developers <adsb-devs@flightaware.com>
-Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools, python3-wheel, python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
+Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools, python3-wheel (>=0.38.4), python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
 Standards-Version: 3.9.3
 Homepage: https://github.com/flightaware
 

--- a/bookworm/control
+++ b/bookworm/control
@@ -2,7 +2,7 @@ Source: piaware
 Section: embedded
 Priority: extra
 Maintainer: FlightAware Developers <adsb-devs@flightaware.com>
-Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools (>=62.6), python3-wheel (>=0.38.4), python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
+Build-Depends: debhelper(>=10), tcl8.6-dev, autoconf, python3-dev(>=3.9), python3-venv, python3-setuptools, python3-wheel (>=0.38.4), python3-build, python3-pip, libz-dev, openssl, libboost-system-dev, libboost-program-options-dev, libboost-regex-dev, libboost-filesystem-dev, patchelf
 Standards-Version: 3.9.3
 Homepage: https://github.com/flightaware
 

--- a/cx_Freeze-8.5.0.patch
+++ b/cx_Freeze-8.5.0.patch
@@ -1,0 +1,21 @@
+diff -ur cx_Freeze-8.5.0/pyproject.toml cx_Freeze-8.5.0.new/pyproject.toml
+--- cx_Freeze-8.5.0/pyproject.toml
++++ cx_Freeze-8.5.0.new/pyproject.toml
+@@ -49,8 +49,7 @@
+ ]
+ dynamic = ["version"]
+ keywords = ["cx-freeze cxfreeze cx_Freeze freeze python"]
+-license = "PSF-2.0"
+-license-files = ["LICENSE.md"]
++license = {text = "PSF-2.0"}
+ readme = "README.md"
+ requires-python = ">=3.10"
+ 
+@@ -105,6 +104,7 @@
+ 
+ [tool.setuptools]
+ include-package-data = true
++license-files = ["LICENSE.md"]
+ zip-safe = false
+ 
+ [tool.setuptools.dynamic]

--- a/freeze-core-0.4.2.patch
+++ b/freeze-core-0.4.2.patch
@@ -1,0 +1,20 @@
+diff -ur freeze-core-0.4.2/pyproject.toml freeze-core-0.4.2.new/pyproject.toml
+--- freeze-core-0.4.2/pyproject.toml
++++ freeze-core-0.4.2.new/pyproject.toml
+@@ -39,8 +39,7 @@
+ ]
+ dynamic = ["version"]
+ keywords = ["freeze-core freeze cx-freeze cxfreeze cx_Freeze python"]
+-license = "MIT"
+-license-files = ["LICENSE"]
++license = {text = "MIT"}
+ readme = "README.md"
+ requires-python = ">=3.10"
+ 
+@@ -68,6 +67,7 @@
+ 
+ [tool.setuptools]
+ include-package-data = true
++license-files = ["LICENSE"]
+ package-dir = {"" = "src"}
+ zip-safe = false

--- a/sensible-build.sh
+++ b/sensible-build.sh
@@ -59,6 +59,11 @@ case $dist in
     targetdist=trixie
     extraversion=""
     ;;
+  jammy)
+    debdist=bullseye
+    targetdist=jammy
+    extraversion="~ubuntu2204+"
+    ;;
   noble)
     debdist=trixie
     targetdist=noble

--- a/sensible-build.sh
+++ b/sensible-build.sh
@@ -65,6 +65,11 @@ case $dist in
     targetdist=jammy
     extraversion="~ubuntu2204+"
     ;;
+  noble)
+    debdist=trixie
+    targetdist=noble
+    extraversion="~ubuntu2404+"
+    ;;
   *)
     echo "unknown build distribution $1" >&2
     usage

--- a/sensible-build.sh
+++ b/sensible-build.sh
@@ -59,23 +59,11 @@ case $dist in
     targetdist=trixie
     extraversion=""
     ;;
-  xenial)
+  jammy)
     # not tested
-    debdist=stretch
-    targetdist=xenial
-    extraversion="~ubuntu1604+"
-    ;;
-  bionic)
-    # not tested
-    debdist=buster
-    targetdist=bionic
-    extraversion="~ubuntu1804+"
-    ;;
-  disco)
-    # not tested
-    debdist=buster
-    targetdist=disco
-    extraversion="~ubuntu1904+"
+    debdist=bookworm
+    targetdist=jammy
+    extraversion="~ubuntu2204+"
     ;;
   noble)
     # not tested

--- a/sensible-build.sh
+++ b/sensible-build.sh
@@ -59,12 +59,6 @@ case $dist in
     targetdist=trixie
     extraversion=""
     ;;
-  jammy)
-    # not tested
-    debdist=bookworm
-    targetdist=jammy
-    extraversion="~ubuntu2204+"
-    ;;
   noble)
     debdist=trixie
     targetdist=noble

--- a/trixie/rules
+++ b/trixie/rules
@@ -84,10 +84,10 @@ build_mlat-client:
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel -C="--build-option=--plat-name" -C="--build-option=$(PYTHON_HOST_PLATFORM)" --outdir $(CURDIR)/wheels freeze-core-0.4.2
 	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/freeze_core-0.4.2*.whl
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel -C="--build-option=--plat-name" -C="--build-option=$(PYTHON_HOST_PLATFORM)" --outdir $(CURDIR)/wheels cx_Freeze-8.5.0
-	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/cx_freeze-8.5.0*.whl
+	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/cx_Freeze-8.5.0-*.whl
 	# build mlat-client proper
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel -C="--build-option=--plat-name" -C="--build-option=$(PYTHON_HOST_PLATFORM)" --outdir $(CURDIR)/wheels mlat-client
-	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/mlatclient-*.whl
+	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/MlatClient-*.whl
 
 install_mlat-client:
 	# newer cxfreeze deletes --target-dir (see cxfreeze issue #1300), so we have to freeze to a temporary directory and

--- a/trixie/rules
+++ b/trixie/rules
@@ -7,6 +7,9 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
+# we need nocaseglob
+SHELL := /bin/bash
+
 PYTHON3 := /usr/bin/$(shell py3versions -d)
 
 VENV=$(CURDIR)/debian/venv
@@ -70,10 +73,12 @@ build_mlat-client:
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel --outdir $(CURDIR)/wheels freeze-core-0.4.2
 	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/freeze_core-0.4.2*.whl
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel --outdir $(CURDIR)/wheels cx_Freeze-8.5.0
-	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/cx_freeze-8.5.0*.whl
+	# nb: trixie and noble produce wheels with different capitalization
+	shopt -s nocaseglob; $(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/cx_freeze-8.5.0*.whl
 	# build mlat-client proper
 	$(VENV)/bin/python -m build --skip-dependency-check --no-isolation --wheel --outdir $(CURDIR)/wheels mlat-client
-	$(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/mlatclient-*.whl
+	# nb: trixie and noble produce wheels with different capitalization
+	shopt -s nocaseglob; $(VENV)/bin/python -m pip install --no-index --no-deps --ignore-installed --require-virtualenv $(CURDIR)/wheels/mlatclient-*.whl
 
 install_mlat-client:
 	# newer cxfreeze deletes --target-dir (see cxfreeze issue #1300), so we have to freeze to a temporary directory and


### PR DESCRIPTION
This adds support for Ubuntu 22.04 (jammy) and 24.04 (noble) in sensible-build.

jammy is based directly on the bullseye build with no changes.

noble is based on the trixie support with a couple of tweaks:

 * patch cxfreeze license metadata (thanks @caiusseverus!) so the version of setuptools in noble is okay with it
 * noble produces wheel files with differing capitalization; set nocaseglob to deal with noble + trixie without too many contortions

Also:

 * add a github actions workflow to test-build on the 22.04 and 24.04 github-hosted runners
 * remove very old Ubuntu versions from sensible-build

Let's squash-merge this one since there's lots of failed experimentation in the git history.
